### PR TITLE
11 diary index

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,0 +1,12 @@
+class DiariesController < ApplicationController
+  def index
+    @selected_date = params[:selected_date] ? Date.parse(params[:selected_date]) : Date.today
+    @start_date = @selected_date.beginning_of_week(:sunday)
+    @end_date = @start_date + 6.days
+    @diaries = current_user.diaries.where(date: @start_date..@end_date).index_by(&:date)
+  end
+
+  def diary_params
+    params.require(:diary).permit(:title, :content, :date)
+  end
+end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,0 +1,6 @@
+class Diary < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :body, presence: true, length: { maximum: 65_535 }
+  
+  belongs_to :user
+end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,6 +1,6 @@
 class Diary < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :body, presence: true, length: { maximum: 65_535 }
-  
+
   belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :diaries, dependent: :destroy
 end

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,0 +1,62 @@
+<div class="container mx-auto my-8 font-sans">
+  <div class="flex justify-between items-center mb-4">
+    <!-- 前の週リンク -->
+    <%= link_to '前', diaries_path(selected_date: @start_date - 1.week), class: "md:hidden block hover:text-amber-700 transition duration-300 text-xl" %>
+    <%= link_to '前の週', diaries_path(selected_date: @start_date - 1.week), class: "hidden md:inline text-blue-500 hover:underline" %>
+
+    <div class="flex items-center">
+      <select data-calendar-target="year" data-action="change->calendar#updateDays" class="border rounded px-2 py-1">
+        <% (Date.today.year-10..Date.today.year+10).each do |year| %>
+          <option value="<%= year %>" <%= 'selected' if year == @selected_date.year %>><%= year %></option>
+        <% end %>
+      </select>
+      <select data-calendar-target="month" data-action="change->calendar#updateDays" class="border rounded px-2 py-1 ml-2">
+        <% (1..12).each do |month| %>
+          <option value="<%= month %>" <%= 'selected' if month == @selected_date.month %>><%= Date::MONTHNAMES[month] %></option>
+        <% end %>
+      </select>
+      <select data-calendar-target="day" class="border rounded px-2 py-1 ml-2">
+        <% (1..31).each do |day| %>
+          <option value="<%= day %>" <%= 'selected' if day == @selected_date.day %>><%= day %></option>
+        <% end %>
+      </select>
+      <button data-action="click->calendar#goToSelectedWeek" class="ml-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">
+        移動
+      </button>
+    </div>
+
+    <!-- 次の週リンク -->
+    <%= link_to '次', diaries_path(selected_date: @start_date + 1.week), class: "md:hidden block hover:text-amber-700 transition duration-300 text-xl" %>  <!-- スマホ -->
+    <%= link_to '次の週', diaries_path(selected_date: @start_date + 1.week), class: "hidden md:inline text-blue-500 hover:underline" %>
+  </div>
+
+  <div class="space-y-4">
+    <% (@start_date..@end_date).each do |date| %>
+      <div class="border-b pb-2">
+        <% if @diaries[date] %>
+          <%= link_to diary_path(@diaries[date]), class: "block hover:bg-gray-100 py-2" do %>
+            <div class="flex justify-between items-center">
+              <span class="text-lg font-bold"><%= date.strftime('%A : %Y/%m/%d') %></span>
+              <span class="text-blue-500 hover:underline">日記を見る</span>
+            </div>
+            <% if @diaries[date].image.present? %>
+              <div class="mt-2">
+                <%= image_tag @diaries[date].image.url, class: "w-full max-w-md rounded" %>
+              </div>
+            <% end %>
+            <p class="mt-2 text-gray-700">
+              <%= truncate(@diaries[date].content, length: 100) %>
+            </p>
+          <% end %>
+        <% else %>
+          <%= link_to "#new_diary_path(date: date)", class: "block hover:bg-gray-100 py-2" do %>
+            <div class="flex justify-between items-center">
+              <span class="text-lg font-bold"><%= date.strftime('%Y年%m月%d日') %>（<%= %w(日 月 火 水 木 金 土)[date.wday] %>）</span>
+              <span class="text-green-500 hover:underline">日記を書く</span>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,7 +11,7 @@
           <!-- ログインしている場合 -->
           <%= link_to 'マイページ', '#', class: "mr-4 hover:font-bold" %>
           <%= link_to '投稿', '#', data: { turbo: false }, class: "mr-4 hover:font-bold" %>
-          <%= link_to '一覧', '#', class: "mr-4 hover:font-bold" %>
+          <%= link_to '一覧', diaries_path, class: "mr-4 hover:font-bold" %>
           <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: "text-gray-700 hover:text-red-500 transition duration-300" %>
         <% else %>
           <!-- 未ログインの場合 -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   # root "tasks#index"
   root "static_pages#top"
   resources :tasks
+  resources :diaries, only: %[index]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # root "tasks#index"
   root "static_pages#top"
   resources :tasks
-  resources :diaries, only: %[index]
+  resources :diaries, only: %i[index]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20241213120455_create_diaries.rb
+++ b/db/migrate/20241213120455_create_diaries.rb
@@ -1,0 +1,11 @@
+class CreateDiaries < ActiveRecord::Migration[7.2]
+  def change
+    create_table :diaries do |t|
+      t.string :title, null: false
+      t.text :body, null: false
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241213123745_add_column_to_diary.rb
+++ b/db/migrate/20241213123745_add_column_to_diary.rb
@@ -1,0 +1,5 @@
+class AddColumnToDiary < ActiveRecord::Migration[7.2]
+  def change
+    add_column :diaries, :date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_13_120455) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_13_123745) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_13_120455) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "date"
     t.index ["user_id"], name: "index_diaries_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_10_044228) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_13_120455) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "diaries", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "body", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_diaries_on_user_id"
+  end
 
   create_table "tasks", force: :cascade do |t|
     t.string "name"
@@ -32,4 +41,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_10_044228) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "diaries", "users"
 end


### PR DESCRIPTION
## 概要
日記一覧機能を追加した。

## 実装
Diaryモデルを生成する。
データベースに以下のカラムを持つDiariesテーブルを生成する。
-title
-body
-user_id
-created_at
-updated_at
日記一覧画面へのルーティングを設定する。
設定したルーティングに対応するコントローラーとアクションを用意する。
用意したコントローラーとアクションに対応するビューを用意する。